### PR TITLE
Add option to overwrite/replace already existing files

### DIFF
--- a/man/detox.1
+++ b/man/detox.1
@@ -68,6 +68,8 @@ Use
 .Pa configfile
 instead of the default configuration files for loading translation sequences.
 No other config file will be parsed.
+.It Fl F
+Overwrite/replace a target file if it already exists.
 .It Fl h , -help
 Display helpful information.
 .It Fl -inline

--- a/src/detox_struct.h
+++ b/src/detox_struct.h
@@ -92,6 +92,7 @@ typedef struct {
     int is_inline_bin;
     int is_inline_mode;
     int list_sequences;
+    int overwrite;
     int recurse;
     int special;
     int verbose;

--- a/src/file.c
+++ b/src/file.c
@@ -128,7 +128,7 @@ char *parse_file(char *filename, options_t *options)
     }
 
     err = lstat(new_filename, &stat_info_new);
-    if (err != -1) { // New file exists
+    if (err != -1 && options->overwrite == 0) { // New file exists
         if (stat_info_old.st_dev != stat_info_new.st_dev || // Different device
                 stat_info_old.st_ino != stat_info_new.st_ino || // Different inode
                 stat_info_old.st_nlink > 1) { // More than one hard link

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -67,6 +67,7 @@ char usage_message[] = {
 
 char help_message[] = {
      "	-f configfile	choose which config file to use\n"
+     "  -F  force, overwrite/replace already existing files\n"
 #ifdef HAVE_GETOPT_LONG
     "	-h --help	this message\n"
 #else
@@ -93,11 +94,12 @@ char help_message[] = {
 };
 
 char usage_message_inline[] = {
-    "usage: inline-detox [-hLvV] [-f configfile] [-s sequence] [file]\n"
+    "usage: inline-detox [-FhLvV] [-f configfile] [-s sequence] [file]\n"
 };
 
 char help_message_inline[] = {
     "	-f configfile	choose which config file to use\n"
+    "   -F      overwrite existing files\n"
 #ifdef HAVE_GETOPT_LONG
     "	-h --help	this message\n"
 #else
@@ -137,9 +139,9 @@ options_t *parse_options_getopt(int argc, char **argv)
                                       (strcmp(binname, INLINE_DETOX_BIN) == 0);
 
 #ifdef HAVE_GETOPT_LONG
-    while ((optcode = getopt_long(argc, argv, "hrvV?Ls:f:n", longopts, NULL)) != -1) {
+    while ((optcode = getopt_long(argc, argv, "FhrvV?Ls:f:n", longopts, NULL)) != -1) {
 #else
-    while ((optcode = getopt(argc, argv, "hrvV?Ls:f:n")) != -1) {
+    while ((optcode = getopt(argc, argv, "FhrvV?Ls:f:n")) != -1) {
 #endif
         switch (optcode) {
             case 'h':
@@ -156,6 +158,10 @@ options_t *parse_options_getopt(int argc, char **argv)
                  */
                 main_options->check_config_file = wrapped_strdup(optarg);
                 break;
+
+            case 'F':
+                    main_options->overwrite = 1;
+                    break;
 
             case 'L':
                 main_options->list_sequences = 1;


### PR DESCRIPTION
Detox stubbornly refuses to overwrite any already existing files. But sometimes, the user wants to overwrite any existing files.

This PR adds an option -F that allows to the user to chose when they want to overwrite existing files.