### PR TITLE
new sequence : fat . for exfat SD card with dos windows file names limitations 

### DIFF
--- a/table/fat.tbl
+++ b/table/fat.tbl
@@ -1,0 +1,16 @@
+# file allocation table  file name  limitations  for exfat SD cards in Linux  or windows partitions 
+
+# originally appeared in cpm basic dos windows and now appear in a myriad devices  including cameras, camcorders, digital photo frames , Mobile phones, PCs,  networks
+
+# try to find a similar looking font to preserve book titles in file names for storage on SD card where these letters often appear  
+
+start
+0x22 ^ # "
+0x23 @ # #
+0x2a ^ # *
+0x3a ; # :
+0x3c ( # <
+0x3e ) # >
+0x5c ; # \
+0x7c ; # |
+end


### PR DESCRIPTION
new sequence : fat . for exfat SD card with dos windows file names limitations 
if you have book files with book titles as filenames and an SD card you will constantly need this to copy to SD card after down load 

book titles often contain these letters especially colon 

when you get this message 

~~~
cp -v \"* $sdd/books/
'"#*:<>?\|' -> '/storage/075C-9000/books/"#*:<>?\|'
cp: cannot create regular file '/storage/075C-9000/books/"#*:<>?\|': Operation not permitted
~~~

you probably have an exfat SD card 

~~~
moint|ack exfat
/dev/block/vold/public:179,1 on /mnt/media_rw/075C-9000 type exfat (rw,dirsync,nosuid,nodev,noexec,noatime,gid=1023,fmask=0007,dmask=0007,allow_utime=0020,iocharset=utf8,errors=remount-ro)
~~~

# test

~~~
vim ~/.detoxrc
sequence fat {
	safe {
		filename "/data/data/com.termux/files/home/etc/fat.tbl";
	};
};
~~~

~~~
printf '"#*:<>?\|'|xxd -g1
touch '"#*:<>?\|'
detox -Lv
detox -n -s fat \"*
~~~

perl rename will accomplish the same thing

~~~
cpan -D File::Replace
cpanm --info File::Replace
perl-rename -v -n 'y,"#*:<>?\\,^@^;();;,' \"*
~~~

# back ground 

exfat became the standard SD card format some time after 2006

> exFAT has been adopted by the SD Association as the default file system for SDXC and SDUC cards larger than 32 GB.

and carried over this ancient limitation to the present world of Linux computers  that never had this lazy solution and found a way to avoid it from the beginning 

this design limitation appeared   in CPM in 70s and was carried over to disk OS in 1981 in great haste with no time for better solution   . this is a way to inspect such an old system  

~~~
dosemu -dumb
C:\>dir d:\?osem*
~~~

one short cut in the design was to forbid all letters that caused annoying bugs and development delays 

# todo aria2 patch

I need detox or perl rename because aria2c don't have any windows flags for SD cards 

I will patch aria2 so I can down load directly to my SD card 

